### PR TITLE
ワードのアニメーション撤廃＆タイトル変更

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>scriptyper</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,19 @@
+.App {
+  width: 100vw;
+  background-color: #282c34;
+  min-height: 100vh;
+  color: white;
+  font-size: calc(10px + 2vmin);
+  overflow: hidden;
+  text-align: center;
+}
 
 .App-logo {
-  text-align: center;
   height: 40vmin;
-  margin-top: 100px;
   pointer-events: none;
   opacity: 0.25;
+  position: absolute;
+  top: 15%;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -14,18 +23,24 @@
 }
 
 .App-header {
-  background-color: #282c34;
-  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
 }
 
 .App-link {
   text-align: center;
+  color: azure;
+  text-decoration: none;
+}
+
+.App-txt {
+  text-align: center;
+}
+
+.App-highlight {
+  margin-top: 250px;
 }
 
 .App-modenav {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,8 +63,8 @@ const App = () => {
             <Route
               path={`/${modeScript}`}
               element={
-                <Link to={"/"} className="App-modenav-li">
-                  <p className="App-link">ESCAPE TO TOP</p>
+                <Link to={"/"} className="App-link">
+                  <p>ESCAPE TO TOP</p>
                 </Link>
               }
             />
@@ -85,7 +85,7 @@ const App = () => {
               path={"/"}
               element={
                 <>
-                  <h3>モードを選択してください。</h3>
+                  <h3 className="App-highlight">モードを選択してください。</h3>
                   <ul className="App-modenav">
                     {modeSelectKeys.map((value, index) => {
                       return (

--- a/src/components/TypingGameComponent.module.scss
+++ b/src/components/TypingGameComponent.module.scss
@@ -12,50 +12,9 @@ $colors-default :#FFFAFA;
     }
 }
 
-@keyframes swiperRight {
-    0% {
-        transform: translateX(0%);
-    }
-
-    100% {
-        transform: translateX(-50%);
-    }
-}
-
-@keyframes swiperLeft {
-    0% {
-        transform: translateX(-50%);
-    }
-
-    100% {
-        transform: translateX(0%);
-    }
-}
-
-.words {
+.TypingGameComponent {
+    width: 100vw;
     text-align: center;
-    min-width: 100vw;
-    height: fit-content;
-    &__option {
-        text-align: center;
-    }
-}
-
-.swiper {
-    &__right {
-        display: flex;
-        justify-content: flex-start;
-        width: 200vw;
-        overflow: hidden;
-        animation: swiperRight 0.5s ease-in 0s 1 normal forwards running;
-    }
-    &__left {
-        display: flex;
-        justify-content: flex-start;
-        width: 200vw;
-        overflow: hidden;
-        animation: swiperLeft 0.5s ease-in 0s 1 normal forwards running;
-    }
 }
 
 .char {
@@ -71,15 +30,6 @@ $colors-default :#FFFAFA;
         &__txt {
             color: $colors-false;
         }
-    }
-}
-
-.string{
-    &__in {
-        animation: inWord 0.25s ease-in 0s 1 normal forwards running;
-    }
-    &__out {
-        animation: outWord 0.25s ease-in 0s 1 normal forwards running;
     }
 }
 
@@ -109,6 +59,7 @@ $colors-default :#FFFAFA;
         &__nav {
             &__li{
                 list-style-type: none;
+                text-decoration: none;
                 margin-top: 6px;
             }
         }

--- a/src/components/TypingGameComponent.tsx
+++ b/src/components/TypingGameComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import TypingGameResult from "./TypingGameResult";
 import styles from "./TypingGameComponent.module.scss";
 
@@ -14,49 +14,48 @@ const TypingGameComponent: React.FC<TypingGameProps> = ({
   randomLevel,
 }) => {
   // Call the hook
-  const [classToggle, setClassToggle] = useState(false);
   const [intRandom, setIntRandom] = useState(0);
   const [charsArray, setCharsArray] = useState(0);
-  const [charsState, setCharsState] = useState([0]);
-  const [calculatingScore, setCalculatingScore] = useState([0]);
-
-  let chars: string[] = [randomWord[intRandom], randomWord[intRandom]];
-
+  const [charsStateL, setCharsStateL] = useState([0]);
+  const [charsStateR, setCharsStateR] = useState([0]);
+  const [calcScore, setCalcScore] = useState([0]);
+  let chars: string = randomWord[intRandom];
+  let isIntRandom: boolean = intRandom % 2 === 0;
+  let charsStateLR: number[] = isIntRandom ? charsStateL : charsStateR;
+  const isLastChar = (charsStateLR: number[]) => {
+    return (
+      (charsStateLR[charsStateLR.length - 1] === 1 ||
+        charsStateLR[charsStateLR.length - 1] === 2) &&
+      calcScore.length < randomLevel.length
+    );
+  };
   const changeCharsState = (charsStateArr: number[]) => {
-    setCharsState(charsStateArr);
-  }
-
+    if (isIntRandom) {
+      setCharsStateL(charsStateArr);
+    } else {
+      setCharsStateR(charsStateArr);
+    }
+  };
   const changeCharsArray = (charsNum: number) => {
     setCharsArray(charsNum);
-  }
-
+  };
   const changeIntRandom = (int: number) => {
     setIntRandom(int);
-  }
-
-  const changeCalculatingScore = (scoreArr: number[]) => {
-    setCalculatingScore(scoreArr);
-  }
-
-  const changeClassToggle = () => {
-    setClassToggle(!classToggle);
-  }
-
+  };
+  const changeCalcScore = (scoreArr: number[]) => {
+    setCalcScore(scoreArr);
+    console.log(calcScore); //レンダリング無限ループ中動かず
+  };
   const judgeTyping = () => {
-    if (
-      (charsState[charsState.length - 1] === 1 ||
-        charsState[charsState.length - 1] === 2) &&
-      calculatingScore.length < 10
-    ) {
-      calculatingScore[intRandom] = !charsState.includes(2)
-      ? randomLevel[intRandom]
-      : 0;
-    changeCalculatingScore(calculatingScore);
+    if (isLastChar(charsStateLR)) {
+      calcScore[intRandom] = !charsStateLR.includes(2)
+        ? randomLevel[intRandom]
+        : 0;
+      changeCalcScore(calcScore);
     }
-  }
-
+  };
   const resetTyping = () => {
-    if (calculatingScore.length !== 10 && charsState.length === 1) {
+    if (calcScore.length !== 10 && charsStateLR.length === 1) {
       let tmpCharsState = [];
       for (let n = 0; n < randomWord[intRandom].split("").length; n++) {
         tmpCharsState.push(0);
@@ -64,107 +63,80 @@ const TypingGameComponent: React.FC<TypingGameProps> = ({
       changeCharsState(tmpCharsState);
     }
   };
-
-  resetTyping();
-
-  console.log(charsState);
-  console.log(classToggle);
-
   const insertTyping = (keyName: string) => {
     if (keyName === randomWord[intRandom].split("")[charsArray]) {
-      charsState[charsArray] = 1;
+      charsStateLR[charsArray] = 1;
     } else {
-      charsState[charsArray] = 2;
+      charsStateLR[charsArray] = 2;
     }
     changeCharsArray(charsArray + 1);
-    changeCharsState(charsState);
+    changeCharsState(charsStateLR);
   };
-
   const deleteTyping = () => {
     if (charsArray > 0) {
-      charsState[charsArray] = 0;
+      charsStateLR[charsArray] = 0;
       changeCharsArray(charsArray - 1);
-      changeCharsState(charsState);
+      changeCharsState(charsStateLR);
     }
   };
-
   const changeTyping = () => {
-    if (
-      (charsState[charsState.length - 1] === 1 ||
-        charsState[charsState.length - 1] === 2) &&
-      calculatingScore.length < 10
-    ) {
-      changeClassToggle();
+    if (isLastChar(charsStateLR)) {
+      changeIntRandom(intRandom + 1);
       changeCharsArray(0);
       changeCharsState([0]);
-      changeIntRandom(intRandom + 1);
-      if (chars[0] === randomWord[intRandom - 1] || chars[1] === null) {
-        chars[0] = randomWord[intRandom];
-      } else if (chars[1] === randomWord[intRandom - 1] || chars[1] === null) {
-        chars[1] = randomWord[intRandom];
-      }
       resetTyping();
     }
   };
-
   judgeTyping();
   changeTyping();
-  //console.log(calculatingScore);
+  resetTyping();
+  console.log(charsStateL);
 
   // Capture and display!
   if (
-    calculatingScore.length === 10 &&
-    (charsState[charsState.length - 1] === 1 ||
-      charsState[charsState.length - 1] === 2)
+    calcScore.length === randomLevel.length &&
+    (charsStateLR[charsStateLR.length - 1] === 1 ||
+      charsStateLR[charsStateLR.length - 1] === 2)
   ) {
     return (
       <TypingGameResult
-        calculatingScore={calculatingScore}
+        calculatingScore={calcScore}
         randomLevel={randomLevel}
       />
     );
   } else {
     return (
-      <div>
-        <div className={classToggle === true ? styles.swiper__right : styles.swiper__left}>
-          {chars.map((value, index) => {
+      <div className={styles.TypingGameComponent}>
+        <h1
+          onKeyDown={(e) => {
+            const key = e.key;
+            if (key === "Backspace") {
+              deleteTyping();
+            } else if (key.length === 1) {
+              insertTyping(key);
+            }
+            e.preventDefault();
+          }}
+          tabIndex={0}
+        >
+          {chars.split("").map((char, index) => {
+            let state = charsStateLR[index];
             return (
-              <div key={index} className={styles.words}>
-                <h1
-                  //className={classToggle === 2 || classToggle === 0 ? styles.string__in : classToggle === 1 ? styles.string__out : undefined}
-                  onKeyDown={(e) => {
-                    const key = e.key;
-                    if (key === "Backspace") {
-                      deleteTyping();
-                    } else if (key.length === 1) {
-                      insertTyping(key);
-                    }
-                    e.preventDefault();
-                  }}
-                  tabIndex={0}
-                >
-                  {value.split("").map((char, index) => {
-                    let state = charsState[index];
-                    return (
-                      <span
-                        key={char + index}
-                        className={
-                          state === 0
-                            ? styles.char__default
-                            : state === 1
-                              ? styles.char__true
-                              : styles.char__false
-                        }
-                      >
-                        {char}
-                      </span>
-                    );
-                  })}
-                </h1>
-              </div>
+              <span
+                key={char + index}
+                className={
+                  state === 0
+                    ? styles.char__default
+                    : state === 1
+                    ? styles.char__true
+                    : styles.char__false
+                }
+              >
+                {char}
+              </span>
             );
           })}
-        </div>
+        </h1>
         <p className={styles.words__option}>LEVEL: {randomLevel[intRandom]}</p>
         <p className={styles.words__option}>{randomMean[intRandom]}</p>
       </div>

--- a/src/components/TypingWordObject.ts
+++ b/src/components/TypingWordObject.ts
@@ -4,7 +4,8 @@ const numRandom = (max: number) => {
     return Math.floor(Math.random() * max);
 }
 
-const TypingWordObject = (mode: {
+const TypingWordObject = (
+  mode: {
     word: string;
     mean: string;
     level: number;


### PR DESCRIPTION
ワード変化時のアニメーション機能を全て撤廃し、cssのクラスを整理、そしてスタイルも再度整理し、ロゴと被る位置にTypingGameComponentを配置。
タブのタイトルを、「scriptyper」としました。
ファビコンは変化させません。